### PR TITLE
Freeplay arenas2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 build/
+classes
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/api/src/main/java/se/cygni/snake/api/event/ArenaUpdateEvent.java
+++ b/api/src/main/java/se/cygni/snake/api/event/ArenaUpdateEvent.java
@@ -11,6 +11,7 @@ import java.util.List;
 public class ArenaUpdateEvent extends GameMessage {
     private final String arenaName;
     private final String gameId;
+    private final Boolean ranked;
     private final List<String> onlinePlayers;
     // private final Rankings rankings;
 
@@ -18,16 +19,19 @@ public class ArenaUpdateEvent extends GameMessage {
     public ArenaUpdateEvent(
             @JsonProperty("arenaName") String arenaName,
             @JsonProperty("gameId") String gameId,
+            @JsonProperty("ranked") Boolean ranked,
             @JsonProperty("onlinePlayers") List<String> onlinePlayers) {
 
         this.arenaName = arenaName;
         this.gameId = gameId;
+        this.ranked = ranked;
         this.onlinePlayers = onlinePlayers;
     }
 
     public ArenaUpdateEvent(ArenaUpdateEvent other) {
         this.arenaName = other.getArenaName();
         this.gameId = other.getGameId();
+        this.ranked = other.ranked;
         this.onlinePlayers = other.getOnlinePlayers();
     }
 
@@ -37,6 +41,10 @@ public class ArenaUpdateEvent extends GameMessage {
 
     public String getGameId() {
         return gameId;
+    }
+
+    public Boolean getRanked() {
+        return ranked;
     }
 
     public List<String> getOnlinePlayers() {

--- a/api/src/main/java/se/cygni/snake/api/event/ArenaUpdateEvent.java
+++ b/api/src/main/java/se/cygni/snake/api/event/ArenaUpdateEvent.java
@@ -6,6 +6,7 @@ import se.cygni.snake.api.GameMessage;
 import se.cygni.snake.api.type.GameMessageType;
 
 import java.util.List;
+import java.util.Map;
 
 @GameMessageType
 public class ArenaUpdateEvent extends GameMessage {
@@ -13,18 +14,20 @@ public class ArenaUpdateEvent extends GameMessage {
     private final String gameId;
     private final Boolean ranked;
     private final List<String> onlinePlayers;
-    // private final Rankings rankings;
+    private final Map<String, Long> rating;
 
     @JsonCreator
     public ArenaUpdateEvent(
             @JsonProperty("arenaName") String arenaName,
             @JsonProperty("gameId") String gameId,
             @JsonProperty("ranked") Boolean ranked,
+            @JsonProperty("rating") Map<String, Long> rating,
             @JsonProperty("onlinePlayers") List<String> onlinePlayers) {
 
         this.arenaName = arenaName;
         this.gameId = gameId;
         this.ranked = ranked;
+        this.rating = rating;
         this.onlinePlayers = onlinePlayers;
     }
 
@@ -32,6 +35,8 @@ public class ArenaUpdateEvent extends GameMessage {
         this.arenaName = other.getArenaName();
         this.gameId = other.getGameId();
         this.ranked = other.ranked;
+        this.rating = other.rating;
+
         this.onlinePlayers = other.getOnlinePlayers();
     }
 
@@ -45,6 +50,10 @@ public class ArenaUpdateEvent extends GameMessage {
 
     public Boolean getRanked() {
         return ranked;
+    }
+
+    public Map<String, Long> getRating() {
+        return rating;
     }
 
     public List<String> getOnlinePlayers() {

--- a/api/src/main/java/se/cygni/snake/api/event/ArenaUpdateEvent.java
+++ b/api/src/main/java/se/cygni/snake/api/event/ArenaUpdateEvent.java
@@ -15,6 +15,25 @@ public class ArenaUpdateEvent extends GameMessage {
     private final Boolean ranked;
     private final List<String> onlinePlayers;
     private final Map<String, Long> rating;
+    private final List<ArenaHistory> gameHistory;
+
+    public static class ArenaHistory {
+        public ArenaHistory(String gameId, List<String> playerPositions) {
+            this.gameId = gameId;
+            this.playerPositions = playerPositions;
+        }
+
+        private final String gameId;
+        private final List<String> playerPositions;
+
+        public String getGameId() {
+            return gameId;
+        }
+
+        public List<String> getPlayerPositions() {
+            return playerPositions;
+        }
+    }
 
     @JsonCreator
     public ArenaUpdateEvent(
@@ -22,13 +41,15 @@ public class ArenaUpdateEvent extends GameMessage {
             @JsonProperty("gameId") String gameId,
             @JsonProperty("ranked") Boolean ranked,
             @JsonProperty("rating") Map<String, Long> rating,
-            @JsonProperty("onlinePlayers") List<String> onlinePlayers) {
+            @JsonProperty("onlinePlayers") List<String> onlinePlayers,
+            @JsonProperty("gameHistory") List<ArenaHistory> gameHistory) {
 
         this.arenaName = arenaName;
         this.gameId = gameId;
         this.ranked = ranked;
         this.rating = rating;
         this.onlinePlayers = onlinePlayers;
+        this.gameHistory = gameHistory;
     }
 
     public ArenaUpdateEvent(ArenaUpdateEvent other) {
@@ -36,6 +57,7 @@ public class ArenaUpdateEvent extends GameMessage {
         this.gameId = other.getGameId();
         this.ranked = other.ranked;
         this.rating = other.rating;
+        this.gameHistory = other.gameHistory;
 
         this.onlinePlayers = other.getOnlinePlayers();
     }
@@ -58,5 +80,9 @@ public class ArenaUpdateEvent extends GameMessage {
 
     public List<String> getOnlinePlayers() {
         return onlinePlayers;
+    }
+
+    public List<ArenaHistory> getGameHistory() {
+        return gameHistory;
     }
 }

--- a/api/src/main/java/se/cygni/snake/api/event/ArenaUpdateEvent.java
+++ b/api/src/main/java/se/cygni/snake/api/event/ArenaUpdateEvent.java
@@ -1,0 +1,45 @@
+package se.cygni.snake.api.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import se.cygni.snake.api.GameMessage;
+import se.cygni.snake.api.type.GameMessageType;
+
+import java.util.List;
+
+@GameMessageType
+public class ArenaUpdateEvent extends GameMessage {
+    private final String arenaName;
+    private final String gameId;
+    private final List<String> onlinePlayers;
+    // private final Rankings rankings;
+
+    @JsonCreator
+    public ArenaUpdateEvent(
+            @JsonProperty("arenaName") String arenaName,
+            @JsonProperty("gameId") String gameId,
+            @JsonProperty("onlinePlayers") List<String> onlinePlayers) {
+
+        this.arenaName = arenaName;
+        this.gameId = gameId;
+        this.onlinePlayers = onlinePlayers;
+    }
+
+    public ArenaUpdateEvent(ArenaUpdateEvent other) {
+        this.arenaName = other.getArenaName();
+        this.gameId = other.getGameId();
+        this.onlinePlayers = other.getOnlinePlayers();
+    }
+
+    public String getArenaName() {
+        return arenaName;
+    }
+
+    public String getGameId() {
+        return gameId;
+    }
+
+    public List<String> getOnlinePlayers() {
+        return onlinePlayers;
+    }
+}

--- a/api/src/main/java/se/cygni/snake/eventapi/request/SetCurrentArena.java
+++ b/api/src/main/java/se/cygni/snake/eventapi/request/SetCurrentArena.java
@@ -1,0 +1,21 @@
+package se.cygni.snake.eventapi.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import se.cygni.snake.eventapi.ApiMessage;
+import se.cygni.snake.eventapi.type.ApiMessageType;
+
+@ApiMessageType
+public class SetCurrentArena extends ApiMessage {
+    private final String currentArena;
+
+    @JsonCreator
+    public SetCurrentArena(
+            @JsonProperty("currentArena") String currentArena) {
+        this.currentArena = currentArena;
+    }
+
+    public String getCurrentArena() {
+        return currentArena;
+    }
+}

--- a/api/src/main/java/se/cygni/snake/eventapi/request/StartArenaGame.java
+++ b/api/src/main/java/se/cygni/snake/eventapi/request/StartArenaGame.java
@@ -1,0 +1,22 @@
+package se.cygni.snake.eventapi.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import se.cygni.snake.eventapi.ApiMessage;
+import se.cygni.snake.eventapi.type.ApiMessageType;
+
+@ApiMessageType
+public class StartArenaGame extends ApiMessage {
+
+    private final String arenaName;
+
+    @JsonCreator
+    public StartArenaGame(
+            @JsonProperty("arenaName") String arenaName) {
+        this.arenaName = arenaName;
+    }
+
+    public String getArenaName() {
+        return arenaName;
+    }
+}

--- a/app/src/main/java/org/goochjs/glicko2/LICENCE.txt
+++ b/app/src/main/java/org/goochjs/glicko2/LICENCE.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2013, Jeremy Gooch
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met: 
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer. 
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/app/src/main/java/org/goochjs/glicko2/Rating.java
+++ b/app/src/main/java/org/goochjs/glicko2/Rating.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2013 Jeremy Gooch <http://www.linkedin.com/in/jeremygooch/>
+ *
+ * The licence covering the contents of this file is described in the file LICENCE.txt,
+ * which should have been included as part of the distribution containing this file.
+ */
+package org.goochjs.glicko2;
+
+/**
+ * Holds an individual's Glicko-2 rating.
+ *
+ * <p>Glicko-2 ratings are an average skill value, a standard deviation and a volatility (how consistent the player is).
+ * Prof Glickman's paper on the algorithm allows scaling of these values to be more directly comparable with existing rating
+ * systems such as Elo or USCF's derivation thereof. This implementation outputs ratings at this larger scale.</p>
+ *
+ * @author Jeremy Gooch
+ */
+public class Rating {
+
+	private String uid; // not actually used by the calculation engine but useful to track whose rating is whose
+	private double rating;
+	private double ratingDeviation;
+	private double volatility;
+	private int numberOfResults = 0; // the number of results from which the rating has been calculated
+
+	 // the following variables are used to hold values temporarily whilst running calculations
+	private double workingRating;
+	private double workingRatingDeviation;
+	private double workingVolatility;
+	
+	/**
+	 * 
+	 * @param uid           An value through which you want to identify the rating (not actually used by the algorithm)
+	 * @param ratingSystem  An instance of the RatingCalculator object
+	 */
+	public Rating(String uid, RatingCalculator ratingSystem) {
+		this.uid = uid;
+		this.rating = ratingSystem.getDefaultRating();
+		this.ratingDeviation = ratingSystem.getDefaultRatingDeviation();
+		this.volatility = ratingSystem.getDefaultVolatility();
+	}
+
+	public Rating(String uid, RatingCalculator ratingSystem, double initRating, double initRatingDeviation, double initVolatility) {
+		this.uid = uid;
+		this.rating = initRating;
+		this.ratingDeviation = initRatingDeviation;
+		this.volatility = initVolatility;
+	}
+
+	/**
+	 * Return the average skill value of the player.
+	 * 
+	 * @return double
+	 */
+	public double getRating() {
+		return this.rating;
+	}
+
+	public void setRating(double rating) {
+		this.rating = rating;
+	}
+
+	/**
+	 * Return the average skill value of the player scaled down
+	 * to the scale used by the algorithm's internal workings.
+	 * 
+	 * @return double
+	 */
+	public double getGlicko2Rating() {
+		return RatingCalculator.convertRatingToGlicko2Scale(this.rating);
+	}
+
+	/**
+	 * Set the average skill value, taking in a value in Glicko2 scale.
+	 * 
+	 * @param double
+	 */
+	public void setGlicko2Rating(double rating) {
+		this.rating = RatingCalculator.convertRatingToOriginalGlickoScale(rating);
+	}
+
+	public double getVolatility() {
+		return volatility;
+	}
+
+	public void setVolatility(double volatility) {
+		this.volatility = volatility;
+	}
+
+	public double getRatingDeviation() {
+		return ratingDeviation;
+	}
+
+	public void setRatingDeviation(double ratingDeviation) {
+		this.ratingDeviation = ratingDeviation;
+	}
+
+	/**
+	 * Return the rating deviation of the player scaled down
+	 * to the scale used by the algorithm's internal workings.
+	 * 
+	 * @return double
+	 */
+	public double getGlicko2RatingDeviation() {
+		return RatingCalculator.convertRatingDeviationToGlicko2Scale( ratingDeviation );
+	}
+
+	/**
+	 * Set the rating deviation, taking in a value in Glicko2 scale.
+	 * 
+	 * @param double
+	 */
+	public void setGlicko2RatingDeviation(double ratingDeviation) {
+		this.ratingDeviation = RatingCalculator.convertRatingDeviationToOriginalGlickoScale( ratingDeviation );
+	}
+
+	/**
+	 * Used by the calculation engine, to move interim calculations into their "proper" places.
+	 * 
+	 */
+	public void finaliseRating() {
+		this.setGlicko2Rating(workingRating);
+		this.setGlicko2RatingDeviation(workingRatingDeviation);
+		this.setVolatility(workingVolatility);
+		
+		this.setWorkingRatingDeviation(0);
+		this.setWorkingRating(0);
+		this.setWorkingVolatility(0);
+	}
+	
+	/**
+	 * Returns a formatted rating for inspection
+	 * 
+	 * @return {ratingUid} / {ratingDeviation} / {volatility} / {numberOfResults}
+	 */
+	@Override
+	public String toString() {
+		return uid + " / " +
+				rating + " / " +
+				ratingDeviation + " / " +
+				volatility + " / " +
+				numberOfResults;
+	}
+	
+	public int getNumberOfResults() {
+		return numberOfResults;
+	}
+
+	public void incrementNumberOfResults(int increment) {
+		this.numberOfResults = numberOfResults + increment;
+	}
+
+	public String getUid() {
+		return uid;
+	}
+
+	public void setWorkingVolatility(double workingVolatility) {
+		this.workingVolatility = workingVolatility;
+	}
+
+	public void setWorkingRating(double workingRating) {
+		this.workingRating = workingRating;
+	}
+
+	public void setWorkingRatingDeviation(double workingRatingDeviation) {
+		this.workingRatingDeviation = workingRatingDeviation;
+	}
+}

--- a/app/src/main/java/org/goochjs/glicko2/RatingCalculator.java
+++ b/app/src/main/java/org/goochjs/glicko2/RatingCalculator.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (C) 2013 Jeremy Gooch <http://www.linkedin.com/in/jeremygooch/>
+ *
+ * The licence covering the contents of this file is described in the file LICENCE.txt,
+ * which should have been included as part of the distribution containing this file.
+ */
+package org.goochjs.glicko2;
+
+import java.util.List;
+
+/**
+ * This is the main calculation engine based on the contents of Glickman's paper.
+ * http://www.glicko.net/glicko/glicko2.pdf
+ * 
+ * @author Jeremy Gooch
+ * 
+ */
+public class RatingCalculator {
+
+	private final static double DEFAULT_RATING =  1500.0;
+	private final static double DEFAULT_DEVIATION =  350;
+	private final static double DEFAULT_VOLATILITY =  0.06;
+	private final static double DEFAULT_TAU =  0.75;
+	private final static double MULTIPLIER =  173.7178;
+	private final static double CONVERGENCE_TOLERANCE =  0.000001;
+	
+	private double tau; // constrains volatility over time
+	private double defaultVolatility;
+	
+	
+	/**
+	 * Standard constructor, taking default values for volatility
+	 */
+	public RatingCalculator() {
+		tau = DEFAULT_TAU;
+		defaultVolatility = DEFAULT_VOLATILITY;
+	}
+
+	
+	/**
+	 * 
+	 * @param initVolatility  Initial volatility for new ratings
+	 * @param tau             How volatility changes over time
+	 */
+	public RatingCalculator(
+			double initVolatility,
+			double tau) {
+		
+		this.defaultVolatility = initVolatility;
+		this.tau = tau;
+	}
+
+	
+	/**
+	 * <p>Run through all players within a resultset and calculate their new ratings.</p>
+	 * <p>Players within the resultset who did not compete during the rating period
+	 * will have see their deviation increase (in line with Prof Glickman's paper).</p>
+	 * <p>Note that this method will clear the results held in the association resultset.</p>
+	 * 
+	 * @param results
+	 */
+	public void updateRatings(RatingPeriodResults results) {
+		for ( Rating player : results.getParticipants() ) {
+			if ( results.getResults(player).size() > 0 ) {
+				calculateNewRating(player, results.getResults(player));
+			} else {
+				// if a player does not compete during the rating period, then only Step 6 applies.
+				// the player's rating and volatility parameters remain the same but deviation increases
+				player.setWorkingRating(player.getGlicko2Rating());
+				player.setWorkingRatingDeviation(calculateNewRD(player.getGlicko2RatingDeviation(), player.getVolatility()));
+				player.setWorkingVolatility(player.getVolatility());
+			}
+		}
+		
+		// now iterate through the participants and confirm their new ratings
+		for ( Rating player : results.getParticipants() ) {
+			player.finaliseRating();
+		}
+		
+		// lastly, clear the result set down in anticipation of the next rating period
+		results.clear();
+	}
+
+	
+	/**
+	 * This is the function processing described in step 5 of Glickman's paper.
+	 *  
+	 * @param player
+	 * @param results
+	 */
+	private void calculateNewRating(Rating player, List<Result> results) {
+		double phi = player.getGlicko2RatingDeviation();
+		double sigma = player.getVolatility();
+		double a = Math.log( Math.pow(sigma, 2) );
+		double delta = delta(player, results);
+		double v = v(player, results);
+		
+		// step 5.2 - set the initial values of the iterative algorithm to come in step 5.4
+		double A = a;
+		double B = 0.0;
+ 		if ( Math.pow(delta, 2) > Math.pow(phi, 2) + v ) {
+			B = Math.log( Math.pow(delta, 2) - Math.pow(phi, 2) - v );			
+		} else {
+			double k = 1;
+			B = a - ( k * Math.abs(tau));
+			
+			while ( f(B , delta, phi, v, a, tau) < 0 ) {
+				k++;
+				B = a - ( k * Math.abs(tau));
+			}
+		}
+
+		// step 5.3
+		double fA = f(A , delta, phi, v, a, tau);
+		double fB = f(B , delta, phi, v, a, tau);
+
+		// step 5.4
+		while ( Math.abs(B - A) > CONVERGENCE_TOLERANCE ) {
+ 			double C = A + (( (A-B)*fA ) / (fB - fA));
+ 			double fC = f(C , delta, phi, v, a, tau);
+ 			
+ 			if ( fC * fB < 0 ) {
+ 				A = B;
+ 				fA = fB;
+ 			} else {	
+ 				fA = fA / 2.0;
+ 			}
+ 			
+ 			B = C;
+ 			fB = fC;
+ 		}
+ 		
+		double newSigma = Math.exp( A/2.0 );
+ 		
+		player.setWorkingVolatility(newSigma);
+
+		// Step 6
+		double phiStar = calculateNewRD( phi, newSigma );
+		
+		// Step 7
+		double newPhi = 1.0 / Math.sqrt(( 1.0 / Math.pow(phiStar, 2) ) + ( 1.0 / v ));
+
+		// note that the newly calculated rating values are stored in a "working" area in the Rating object
+		// this avoids us attempting to calculate subsequent participants' ratings against a moving target
+		player.setWorkingRating(
+				player.getGlicko2Rating()
+				+ ( Math.pow(newPhi, 2) * outcomeBasedRating(player, results)));
+		player.setWorkingRatingDeviation(newPhi);
+		player.incrementNumberOfResults(results.size());
+	}
+	
+	private double f(double x, double delta, double phi, double v, double a, double tau) {
+		return ( Math.exp(x) * ( Math.pow(delta, 2) - Math.pow(phi, 2) - v - Math.exp(x) ) /
+				(2.0 * Math.pow( Math.pow(phi, 2) + v + Math.exp(x), 2) )) - 
+				( ( x - a ) / Math.pow(tau, 2) );
+	}
+	
+	
+	/**
+	 * This is the first sub-function of step 3 of Glickman's paper.
+	 * 
+	 * @param deviation
+	 * @return
+	 */
+	private double g(double deviation) {
+		return 1.0 / ( Math.sqrt( 1.0 + ( 3.0 * Math.pow(deviation, 2) / Math.pow(Math.PI,2) )));
+	}
+	
+	
+	/**
+	 * This is the second sub-function of step 3 of Glickman's paper.
+	 * 
+	 * @param playerRating
+	 * @param opponentRating
+	 * @param opponentDeviation
+	 * @return
+	 */
+	private double E(double playerRating, double opponentRating, double opponentDeviation) {
+		return 1.0 / (1.0 + Math.exp( -1.0 * g(opponentDeviation) * ( playerRating - opponentRating )));
+	}
+	
+	
+	/**
+	 * This is the main function in step 3 of Glickman's paper.
+	 * 
+	 * @param player
+	 * @param results
+	 * @return
+	 */
+	private double v(Rating player, List<Result> results) {
+		double v = 0.0;
+		
+		for ( Result result: results ) {
+			v = v + (
+					( Math.pow( g(result.getOpponent(player).getGlicko2RatingDeviation()), 2) )
+					* E(player.getGlicko2Rating(),
+							result.getOpponent(player).getGlicko2Rating(),
+							result.getOpponent(player).getGlicko2RatingDeviation())
+					* ( 1.0 - E(player.getGlicko2Rating(),
+							result.getOpponent(player).getGlicko2Rating(),
+							result.getOpponent(player).getGlicko2RatingDeviation())
+					));
+		}
+		
+		return Math.pow(v, -1);
+	}
+	
+	
+	/**
+	 * This is a formula as per step 4 of Glickman's paper.
+	 * 
+	 * @param player
+	 * @param results
+	 * @return delta
+	 */
+	private double delta(Rating player, List<Result> results) {
+		return v(player, results) * outcomeBasedRating(player, results);
+	}
+	
+	
+	/**
+	 * This is a formula as per step 4 of Glickman's paper.
+	 * 
+	 * @param player
+	 * @param results
+	 * @return expected rating based on game outcomes
+	 */
+	private double outcomeBasedRating(Rating player, List<Result> results) {
+		double outcomeBasedRating = 0;
+		
+		for ( Result result: results ) {
+			outcomeBasedRating = outcomeBasedRating
+					+ ( g(result.getOpponent(player).getGlicko2RatingDeviation())
+						* ( result.getScore(player) - E(
+								player.getGlicko2Rating(),
+								result.getOpponent(player).getGlicko2Rating(),
+								result.getOpponent(player).getGlicko2RatingDeviation() ))
+				);
+		}
+		
+		return outcomeBasedRating;
+	}
+	
+	
+	/**
+	 * This is the formula defined in step 6. It is also used for players
+	 * who have not competed during the rating period.
+	 * 
+	 * @param phi
+	 * @param sigma
+	 * @return new rating deviation
+	 */
+	private double calculateNewRD(double phi, double sigma) {
+		return Math.sqrt( Math.pow(phi, 2) + Math.pow(sigma, 2) );
+	}
+
+	
+	/**
+	 * Converts from the value used within the algorithm to a rating in the same range as traditional Elo et al
+	 * 
+	 * @param rating in Glicko2 scale
+	 * @return rating in Glicko scale
+	 */
+	public static double convertRatingToOriginalGlickoScale(double rating) {
+		return ( ( rating  * MULTIPLIER ) + DEFAULT_RATING );
+	}
+	
+	
+	/**
+	 * Converts from a rating in the same range as traditional Elo et al to the value used within the algorithm
+	 * 
+	 * @param rating in Glicko scale
+	 * @return rating in Glicko2 scale
+	 */
+	public static double convertRatingToGlicko2Scale(double rating) {
+		return ( ( rating  - DEFAULT_RATING ) / MULTIPLIER ) ;
+	}
+	
+	
+	/**
+	 * Converts from the value used within the algorithm to a rating deviation in the same range as traditional Elo et al
+	 * 
+	 * @param ratingDeviation in Glicko2 scale
+	 * @return ratingDeviation in Glicko scale
+	 */
+	public static double convertRatingDeviationToOriginalGlickoScale(double ratingDeviation) {
+		return ( ratingDeviation * MULTIPLIER ) ;
+	}
+	
+	
+	/**
+	 * Converts from a rating deviation in the same range as traditional Elo et al to the value used within the algorithm
+	 * 
+	 * @param ratingDeviation in Glicko scale
+	 * @return ratingDeviation in Glicko2 scale
+	 */
+	public static double convertRatingDeviationToGlicko2Scale(double ratingDeviation) { 
+		return ( ratingDeviation / MULTIPLIER );
+	}
+
+	
+	public double getDefaultRating() {
+		return DEFAULT_RATING;
+	}
+
+	
+	public double getDefaultVolatility() {
+		return defaultVolatility;
+	}
+
+	
+	public double getDefaultRatingDeviation() {
+		return DEFAULT_DEVIATION;
+	}
+}
+
+
+

--- a/app/src/main/java/org/goochjs/glicko2/RatingPeriodResults.java
+++ b/app/src/main/java/org/goochjs/glicko2/RatingPeriodResults.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2013 Jeremy Gooch <http://www.linkedin.com/in/jeremygooch/>
+ *
+ * The licence covering the contents of this file is described in the file LICENCE.txt,
+ * which should have been included as part of the distribution containing this file.
+ */
+package org.goochjs.glicko2;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This class holds the results accumulated over a rating period.
+ * 
+ * @author Jeremy Gooch
+ */
+public class RatingPeriodResults {
+	private List<Result> results = new ArrayList<Result>();
+	private Set<Rating> participants = new HashSet<Rating>();
+
+	
+	/**
+	 * Create an empty resultset.
+	 */
+	public RatingPeriodResults() {}
+	
+
+	/**
+	 * Constructor that allows you to initialise the list of participants.
+	 * 
+	 * @param participants (Set of Rating objects)
+	 */
+	public RatingPeriodResults(Set<Rating> participants) {
+		this.participants = participants;
+	}
+	
+	
+	/**
+	 * Add a result to the set.
+	 * 
+	 * @param winner
+	 * @param loser
+	 */
+	public void addResult(Rating winner, Rating loser) {
+		Result result = new Result(winner, loser);
+		
+		results.add(result);
+	}
+	
+	
+	/**
+	 * Record a draw between two players and add to the set.
+	 * 
+	 * @param player1
+	 * @param player2
+	 */
+	public void addDraw(Rating player1, Rating player2) {
+		Result result = new Result(player1, player2, true);
+		
+		results.add(result);
+	}
+	
+	
+	/**
+	 * Get a list of the results for a given player.
+	 * 
+	 * @param player
+	 * @return List of results
+	 */
+	public List<Result> getResults(Rating player) {
+		List<Result> filteredResults = new ArrayList<Result>();
+		
+		for ( Result result : results ) {
+			if ( result.participated(player) ) {
+				filteredResults.add(result);
+			}
+		}
+		
+		return filteredResults;
+	}
+
+	
+	/**
+	 * Get all the participants whose results are being tracked.
+	 * 
+	 * @return set of all participants covered by the resultset.
+	 */
+	public Set<Rating> getParticipants() {
+		// Run through the results and make sure all players have been pushed into the participants set.
+		for ( Result result : results ) {
+			participants.add(result.getWinner());
+			participants.add(result.getLoser());
+		}
+
+		return participants;
+	}
+	
+	
+	/**
+	 * Add a participant to the rating period, e.g. so that their rating will
+	 * still be calculated even if they don't actually compete.
+	 *
+	 * @param rating
+	 */
+	public void addParticipants(Rating rating) {
+		participants.add(rating);
+	}
+	
+	
+	/**
+	 * Clear the resultset.
+	 */
+	public void clear() {
+		results.clear();
+	}
+}

--- a/app/src/main/java/org/goochjs/glicko2/Result.java
+++ b/app/src/main/java/org/goochjs/glicko2/Result.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2013 Jeremy Gooch <http://www.linkedin.com/in/jeremygooch/>
+ *
+ * The licence covering the contents of this file is described in the file LICENCE.txt,
+ * which should have been included as part of the distribution containing this file.
+ */
+package org.goochjs.glicko2;
+
+/**
+ * Represents the result of a match between two players.
+ * 
+ * @author Jeremy Gooch
+ */
+public class Result {
+	private static final double POINTS_FOR_WIN = 1.0;
+	private static final double POINTS_FOR_LOSS = 0.0;
+	private static final double POINTS_FOR_DRAW = 0.5;
+	
+	private boolean isDraw = false;
+	private Rating winner;
+	private Rating loser;
+	
+	
+	/**
+	 * Record a new result from a match between two players.
+	 * 
+	 * @param winner
+	 * @param loser
+	 */
+	public Result(Rating winner, Rating loser) {
+		if ( ! validPlayers(winner, loser) ) {
+			throw new IllegalArgumentException();
+		}
+
+		this.winner = winner;
+		this.loser = loser;
+	}
+	
+	
+	/**
+	 * Record a draw between two players.
+	 * 
+	 * @param player1
+	 * @param player2
+	 * @param isDraw (must be set to "true")
+	 */
+	public Result(Rating player1, Rating player2, boolean isDraw) {
+		if (! isDraw || ! validPlayers(player1, player2) ) {
+			throw new IllegalArgumentException();
+		}
+		
+		this.winner = player1;
+		this.loser = player2;
+		this.isDraw = true;
+	}
+
+	
+	/**
+	 * Check that we're not doing anything silly like recording a match with only one player.
+	 * 
+	 * @param player1
+	 * @param player2
+	 * @return
+	 */
+	private boolean validPlayers(Rating player1, Rating player2) {
+		if (player1.equals(player2)) {
+			return false;
+		} else {
+			return true;
+		}
+	}
+	
+	
+	/**
+	 * Test whether a particular player participated in the match represented by this result.
+	 * 
+	 * @param player
+	 * @return boolean (true if player participated in the match)
+	 */
+	public boolean participated(Rating player) {
+		if ( winner.equals(player) || loser.equals(player) ) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+	
+	
+	/**
+	 * Returns the "score" for a match.
+	 * 
+	 * @param player
+	 * @return 1 for a win, 0.5 for a draw and 0 for a loss
+	 * @throws IllegalArgumentException
+	 */
+	public double getScore(Rating player) throws IllegalArgumentException {
+		double score;
+		
+		if ( winner.equals(player) ) {
+			score = POINTS_FOR_WIN;
+		} else if ( loser.equals(player) ) {
+			score = POINTS_FOR_LOSS;			
+		} else {
+			throw new IllegalArgumentException("Player " + player.getUid() + " did not participate in match");
+		}
+		
+		if ( isDraw ) {
+			score = POINTS_FOR_DRAW;
+		}
+		
+		return score;
+	}
+	
+	
+	/**
+	 * Given a particular player, returns the opponent.
+	 * 
+	 * @param player
+	 * @return opponent
+	 */
+	public Rating getOpponent(Rating player) {
+		Rating opponent;
+		
+		if ( winner.equals(player) ) {
+			opponent = loser;
+		} else if ( loser.equals(player) ) {
+			opponent = winner;			
+		} else {
+			throw new IllegalArgumentException("Player " + player.getUid() + " did not participate in match");
+		}
+		
+		return opponent;
+	}
+	
+	
+	public Rating getWinner() {
+		return this.winner;
+	}
+
+	
+	public Rating getLoser() {
+		return this.loser;
+	}
+}

--- a/app/src/main/java/se/cygni/snake/arena/ArenaManager.java
+++ b/app/src/main/java/se/cygni/snake/arena/ArenaManager.java
@@ -44,7 +44,7 @@ public class ArenaManager {
     private Game currentGame = null;
     private double currentGameStartTime;
 
-
+    ArenaRater rater = new ArenaRater();
 
     public ArenaManager(GameManager gameManager, EventBus globalEventBus) {
         this.gameManager = gameManager;
@@ -120,7 +120,7 @@ public class ArenaManager {
         String gameId = currentGame != null ? currentGame.getGameId() : null;
         List<String> onlinePlayers = connectedPlayers.stream().map(Player::getName).collect(Collectors.toList());
         globalEventBus.post(new InternalGameEvent(
-                System.currentTimeMillis(), new ArenaUpdateEvent(arenaName, gameId, ranked, onlinePlayers)));
+                System.currentTimeMillis(), new ArenaUpdateEvent(arenaName, gameId, ranked, rater.getRating(), onlinePlayers)));
     }
 
     private void processCurrentGame() {
@@ -197,8 +197,7 @@ public class ArenaManager {
 
     private void processEndedGame() {
         if (ranked) {
-            // TODO calculate rankings
-            // TODO store rankings
+            rater.addGameToResult(currentGame);
         }
 
         broadcastState();

--- a/app/src/main/java/se/cygni/snake/arena/ArenaManager.java
+++ b/app/src/main/java/se/cygni/snake/arena/ArenaManager.java
@@ -65,7 +65,7 @@ public class ArenaManager {
         player.setPlayerId(playerId);
 
         // TODO remove duplicated code and add password or similar anti-fakenicking
-        if (connectedPlayers.contains(player)) {
+        if (connectedPlayers.stream().anyMatch(otherPlayer -> otherPlayer.getName().equals(player.getName()))) {
             int removeDupWarning = 0;
             InvalidPlayerName playerNameTaken = new InvalidPlayerName(InvalidPlayerName.PlayerNameInvalidReason.Taken);
             MessageUtils.copyCommonAttributes(registerPlayer, playerNameTaken);

--- a/app/src/main/java/se/cygni/snake/arena/ArenaManager.java
+++ b/app/src/main/java/se/cygni/snake/arena/ArenaManager.java
@@ -44,6 +44,8 @@ public class ArenaManager {
     private Game currentGame = null;
     private double currentGameStartTime;
 
+
+
     public ArenaManager(GameManager gameManager, EventBus globalEventBus) {
         this.gameManager = gameManager;
 

--- a/app/src/main/java/se/cygni/snake/arena/ArenaRater.java
+++ b/app/src/main/java/se/cygni/snake/arena/ArenaRater.java
@@ -1,0 +1,133 @@
+package se.cygni.snake.arena;
+
+import org.goochjs.glicko2.Rating;
+import org.goochjs.glicko2.RatingCalculator;
+import org.goochjs.glicko2.RatingPeriodResults;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import se.cygni.snake.game.Game;
+import se.cygni.snake.player.IPlayer;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ArenaRater {
+    private static final Logger log = LoggerFactory.getLogger(ArenaRater.class);
+
+    private Map<String, Long> rating = new HashMap<>();
+    private List<GameResult> gameResults = new ArrayList<>();
+
+    public static class GameResult {
+        LocalDate date;
+        List<String> positions = new ArrayList<>();
+    }
+
+    public Map<String, Long> getRating() {
+        return rating;
+    }
+
+    public void initializeWithPersistedGameResults() {
+        // TODO ArenaRater is in memory only for now, but should probably be initialized with game history on startup
+    }
+
+    public void addGameToResult(Game game) {
+        GameResult res = new GameResult();
+        res.date = LocalDate.now();
+        res.positions = game.getGameResult()
+                .getSortedResult()
+                .stream()
+                .map(IPlayer::getName)
+                .collect(Collectors.toList());
+        gameResults.add(res);
+
+        calculateRating();
+    }
+
+    // this will redo calculations from scratch on every rating
+    // could be optimixed, but is fast enough with 100000 games in under 1s
+    private void calculateRating() {
+        SortedMap<LocalDate, List<GameResult>> resultsByDate = new TreeMap<>(
+                gameResults.stream()
+                        .collect(Collectors.groupingBy(gr -> gr.date, Collectors.toList())));
+
+        // The initial volatility is set to pretty high, to allow non competing snakes to fall rapidly in rank
+        RatingCalculator ratingCalculator = new RatingCalculator(1, 0.5);
+
+        Map<String, Rating> ratings = gameResults.stream()
+                .flatMap(g -> g.positions.stream())
+                .distinct()
+                .collect(Collectors.toMap(name -> name, name -> new Rating(name, ratingCalculator)));
+
+        resultsByDate
+                .keySet()
+                .forEach(date -> {
+                    rateDay(ratingCalculator, ratings, resultsByDate.get(date));
+                    log.info("Calucated ratings for "+date);
+                    log.info(""+convertRating(ratings));
+                });
+
+        rating.putAll(convertRating(ratings));
+    }
+
+    private Map<String, Long> convertRating(Map<String, Rating> ratings) {
+        Map<String, Long> ret = new HashMap<>();
+        ratings.forEach((name,rating) ->
+                ret.put(name, Math.round(rating.getRating() - 2 * rating.getRatingDeviation()))
+        );
+        return ret;
+    }
+
+    // Each day counts as a rating period, meaning that higher ratings get lost
+    private void rateDay(RatingCalculator ratingCalculator, Map<String, Rating> ratings, List<GameResult> gameResults) {
+        RatingPeriodResults dayResults = new RatingPeriodResults();
+
+        // Add all players as participants, to get players not participating to lose rank
+        ratings.values().forEach(dayResults::addParticipants);
+
+        // Every player is considered to have a win against the player lower on the ranking list
+        gameResults.forEach(gr -> {
+            for (int i=0; i<gr.positions.size(); i++) {
+                for (int j=i+1; j<gr.positions.size(); j++) {
+                    Rating p1 = ratings.get(gr.positions.get(i));
+                    Rating p2 = ratings.get(gr.positions.get(j));
+                    dayResults.addResult(p1, p2);
+                }
+            }
+        });
+
+        ratingCalculator.updateRatings(dayResults);
+    }
+
+    // Code for testing and experimenting
+    public static void main(String[] args) {
+        ArenaRater testRater = new ArenaRater();
+
+        LocalDate date = LocalDate.now();
+
+        int days = 14;
+
+        for (int i = 0; i<days; i++) {
+            for (int j = 0; j<100; j++) {
+                GameResult res = new GameResult();
+                res.date = date;
+                if (i < days / 2) {
+                    res.positions = Arrays.asList("player1", "player2", "player3");
+                } else {
+                    // The leader quits
+                    res.positions = Arrays.asList("player2", "player3");
+                }
+                testRater.gameResults.add(res);
+            }
+
+            date = date.plus(1, ChronoUnit.DAYS);
+        }
+
+        long time = System.nanoTime();
+        testRater.calculateRating();
+        System.err.println("Time elapsed "+(System.nanoTime() - time) / 1e9);
+        System.err.println(testRater.rating);
+    }
+
+}

--- a/app/src/main/java/se/cygni/snake/arena/ArenaRater.java
+++ b/app/src/main/java/se/cygni/snake/arena/ArenaRater.java
@@ -21,6 +21,7 @@ public class ArenaRater {
 
     public static class GameResult {
         LocalDate date;
+        String gameId;
         List<String> positions = new ArrayList<>();
     }
 
@@ -28,11 +29,15 @@ public class ArenaRater {
         return rating;
     }
 
+    public List<GameResult> getGameResults() {
+        return gameResults;
+    }
+
     public void initializeWithPersistedGameResults() {
         // TODO ArenaRater is in memory only for now, but should probably be initialized with game history on startup
     }
 
-    public void addGameToResult(Game game) {
+    public void addGameToResult(Game game, boolean ranked) {
         GameResult res = new GameResult();
         res.date = LocalDate.now();
         res.positions = game.getGameResult()
@@ -40,9 +45,16 @@ public class ArenaRater {
                 .stream()
                 .map(IPlayer::getName)
                 .collect(Collectors.toList());
+        res.gameId = game.getGameId();
         gameResults.add(res);
 
-        calculateRating();
+        if (ranked) {
+            calculateRating();
+        }
+    }
+
+    public boolean hasGame(String gameId) {
+        return gameResults.stream().anyMatch(gr -> gr.gameId.equals(gameId));
     }
 
     // this will redo calculations from scratch on every rating

--- a/app/src/main/java/se/cygni/snake/arena/ArenaSelectionManager.java
+++ b/app/src/main/java/se/cygni/snake/arena/ArenaSelectionManager.java
@@ -1,12 +1,14 @@
 package se.cygni.snake.arena;
 
 
+import com.google.common.eventbus.EventBus;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import se.cygni.snake.game.GameManager;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,21 +18,27 @@ public class ArenaSelectionManager {
     public static final String OFFICIAL_ARENA_NAME = "official";
     private static final Logger log = LoggerFactory.getLogger(ArenaSelectionManager.class);
 
+    private final GameManager gameManager;
+    private final EventBus globalEventBus;
+
     private Map<String, ArenaManager> arenas = new HashMap<>();
 
     @Autowired
-    private ObjectFactory<ArenaManager> arenaManagerObjectFactory;
+    public ArenaSelectionManager(GameManager gameManager, EventBus globalEventBus) {
+        this.gameManager = gameManager;
+        this.globalEventBus = globalEventBus;
+    }
 
     public synchronized ArenaManager getArena(String arenaName) {
-        ArenaManager ret = arenas.get(arenaName);
-
         if (StringUtils.isEmpty(arenaName)) {
             arenaName = OFFICIAL_ARENA_NAME;
         }
 
+        ArenaManager ret = arenas.get(arenaName);
+
         if (ret == null) {
 
-            ret = arenaManagerObjectFactory.getObject();
+            ret = createNewArenaManager();
             ret.setArenaName(arenaName);
             if (arenaName.equals(OFFICIAL_ARENA_NAME)) {
                 ret.setRanked(true);
@@ -40,5 +48,14 @@ public class ArenaSelectionManager {
         }
 
         return ret;
+    }
+
+    private ArenaManager createNewArenaManager() {
+        return new ArenaManager(gameManager, globalEventBus);
+    }
+
+    @Scheduled(fixedRate = 1000)
+    public void runGameScheduler() {
+        arenas.values().forEach(ArenaManager::runGameScheduler);
     }
 }

--- a/app/src/main/java/se/cygni/snake/arena/ArenaSelectionManager.java
+++ b/app/src/main/java/se/cygni/snake/arena/ArenaSelectionManager.java
@@ -1,6 +1,7 @@
 package se.cygni.snake.arena;
 
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectFactory;
@@ -12,6 +13,7 @@ import java.util.Map;
 
 @Component
 public class ArenaSelectionManager {
+    public static final String OFFICIAL_ARENA_NAME = "official";
     private static final Logger log = LoggerFactory.getLogger(ArenaSelectionManager.class);
 
     private Map<String, ArenaManager> arenas = new HashMap<>();
@@ -22,9 +24,17 @@ public class ArenaSelectionManager {
     public synchronized ArenaManager getArena(String arenaName) {
         ArenaManager ret = arenas.get(arenaName);
 
+        if (StringUtils.isEmpty(arenaName)) {
+            arenaName = OFFICIAL_ARENA_NAME;
+        }
+
         if (ret == null) {
+
             ret = arenaManagerObjectFactory.getObject();
             ret.setArenaName(arenaName);
+            if (arenaName.equals(OFFICIAL_ARENA_NAME)) {
+                ret.setRanked(true);
+            }
             arenas.put(arenaName, ret);
             log.info("Created new arena with name "+arenaName);
         }

--- a/app/src/main/java/se/cygni/snake/config/WebSocketConfig.java
+++ b/app/src/main/java/se/cygni/snake/config/WebSocketConfig.java
@@ -22,7 +22,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
         registry.addHandler(eventWebSocketHandler(), "/events-native").setAllowedOrigins("*");
         registry.addHandler(snakeTrainingWebSocketHandler(), "/training");
         registry.addHandler(snakeTournamentWebSocketHandler(), "/tournament");
-        registry.addHandler(snakeArenaWebSocketHandler(), "/arena/{arenaName}");
+        registry.addHandler(snakeArenaWebSocketHandler(), "/arena", "/arena/", "/arena/{arenaName}");
     }
 
     @Bean

--- a/app/src/main/java/se/cygni/snake/websocket/arena/ArenaWebSocketHandler.java
+++ b/app/src/main/java/se/cygni/snake/websocket/arena/ArenaWebSocketHandler.java
@@ -31,13 +31,10 @@ public class ArenaWebSocketHandler extends BaseGameSocketHandler {
 
         String uri = session.getUri().getPath();
 
-        String arenaName = "official-ranked";
-        String arenaFromUri = uri.replaceAll(".*/", "");
-        if (arenaFromUri.length() > 0) {
-            if (arenaFromUri.matches(ARENA_NAME_WHITELIST)) {
-                arenaName = arenaFromUri;
-            } else {
-                handleInvalidName(uri, arenaFromUri);
+        String arenaName = uri.replaceAll(".*/", "");
+        if (arenaName.length() > 0) {
+            if (!arenaName.matches(ARENA_NAME_WHITELIST)) {
+                handleInvalidName(uri, arenaName);
                 return;
             }
         }

--- a/app/src/main/java/se/cygni/snake/websocket/event/EventSocketHandler.java
+++ b/app/src/main/java/se/cygni/snake/websocket/event/EventSocketHandler.java
@@ -106,8 +106,8 @@ public class EventSocketHandler extends TextWebSocketHandler {
 
             } else if (apiMessage instanceof StartGame) {
                 startGame((StartGame) apiMessage);
-
-
+            } else if (apiMessage instanceof StartArenaGame) {
+                startArenaGame((StartArenaGame) apiMessage);
             } else if (apiMessage instanceof GetActiveTournament) {
                 if(tournamentManager.isTournamentActive()) {
                     sendApiMessage(tournamentManager.getTournamentInfo());
@@ -285,6 +285,10 @@ public class EventSocketHandler extends TextWebSocketHandler {
             log.info("Active remote players: {}", game.getPlayerManager().getLiveAndRemotePlayers().size());
             game.startGame();
         }
+    }
+
+    private void startArenaGame(StartArenaGame apiMessage) {
+        arenaSelectionManager.getArena(apiMessage.getArenaName()).requestGameStart();
     }
 
     private boolean verifyTokenSendErrorIfUnauthorized(ApiMessage apiMessage) {


### PR DESCRIPTION
Second part of arenas #61

* Add private/unranked arenas where players (or multiple instances of one players bot) can meet and play. Games can be manually started here.
* Add events for frontend communication for arenas.
* Implement ranking algorithm for ranked arena

Possible future work:

* Rankings are currently stored in memory, and will die when server is restarted. They should probably be persisted, either by saving them to elastic or by reading game history on startup and re-calculating rankings.
* There is no protection for "fakenicking" (if a snake is offline). A method for a client to reserve a name with a password (that would need to be persisted) could be added.
* Maybe there should be an admin-option to disable the ranked/official arena during tournaments or student events. The tournament could be less exciting if the contestants have a solid ranking against each other.